### PR TITLE
Default Values on Configure Form & Save Values as Numerical

### DIFF
--- a/src/containers/Configure/Configure.js
+++ b/src/containers/Configure/Configure.js
@@ -3,12 +3,12 @@ import { Switch, Route, Redirect } from "react-router-dom";
 import './Configure.css';
 
 const Configure = (props) => {
-  const [systemSize, updateSystemSize] = useState('')
-  const [moduleType, updateModuleType] = useState('')
-  const [arrayType, updateArrayType] = useState('')
-  const [systemLosses, updateSystemLosses] = useState('')
-  const [tilt, updateTilt] = useState('')
-  const [azimuth, updateAzimuth] = useState('')
+  const [systemSize, updateSystemSize] = useState(null)
+  const [moduleType, updateModuleType] = useState(null)
+  const [arrayType, updateArrayType] = useState(null)
+  const [systemLosses, updateSystemLosses] = useState(null)
+  const [tilt, updateTilt] = useState(null)
+  const [azimuth, updateAzimuth] = useState(null)
 
   return (
     <section className="configure-container">
@@ -22,7 +22,7 @@ const Configure = (props) => {
             placeholder="4"
             value={systemSize}
             required
-            onChange={e => updateSystemSize(e.target.value)}
+            onChange={e => updateSystemSize(parseFloat(e.target.value))}
           />
         </div>
         <div className="label-input-container">
@@ -30,12 +30,12 @@ const Configure = (props) => {
           <select
             className="configure-selects"
             defaultValue={'DEFAULT'}
-            onChange={e => updateModuleType(e.target.value)}
+            onChange={e => updateModuleType(parseInt(e.target.value))}
           >
             <option value='DEFAULT' disabled>Select Module..</option>
-            <option>Standard</option>
-            <option>Premium</option>
-            <option>Thin Film</option>
+            <option value={0}>Standard</option>
+            <option value={1}>Premium</option>
+            <option value={2}>Thin Film</option>
           </select>
         </div>
         <div className="label-input-container">
@@ -43,14 +43,14 @@ const Configure = (props) => {
           <select
             className="configure-selects"
             defaultValue={'DEFAULT'}
-            onChange={e => updateArrayType(e.target.value)}
+            onChange={e => updateArrayType(parseInt(e.target.value))}
           >
             <option value='DEFAULT' disabled>Select Array..</option>
-            <option>Fixed (open rack)</option>
-            <option>Fixed (roof mount)</option>
-            <option>1-Axis Tracking</option>
-            <option>1-Axis Backtracking</option>
-            <option>2-Axis Tracking</option>
+            <option value={0}>Fixed (open rack)</option>
+            <option value={1}>Fixed (roof mount)</option>
+            <option value={2}>1-Axis Tracking</option>
+            <option value={3}>1-Axis Backtracking</option>
+            <option value={4}>2-Axis Tracking</option>
           </select>
         </div>
         <div className="label-input-container">
@@ -60,7 +60,7 @@ const Configure = (props) => {
             placeholder="14"
             value={systemLosses}
             required
-            onChange={e => updateSystemLosses(e.target.value)}
+            onChange={e => updateSystemLosses(parseFloat(e.target.value))}
           />
         </div>
         <div className="label-input-container">
@@ -70,7 +70,7 @@ const Configure = (props) => {
             placeholder="20"
             value={tilt}
             required
-            onChange={e => updateTilt(e.target.value)}
+            onChange={e => updateTilt(parseFloat(e.target.value))}
           />
         </div>
         <div className="label-input-container">
@@ -80,7 +80,7 @@ const Configure = (props) => {
             placeholder="180"
             value={azimuth}
             required
-            onChange={e => updateAzimuth(e.target.value)}
+            onChange={e => updateAzimuth(parseFloat(e.target.value))}
           />
         </div>
       </form>


### PR DESCRIPTION
**Please include a summary of the change:**
Fixes an issue where the values of array_type and module_type were saved as a string (e.g., "Standard") instead of a value the NREL API is going to accept. This update saves these selections to state according to their corresponding NREL values:

```
Module type:
0 Standard
1 Premium
2 Thin film

Array type:
0 Fixed - Open Rack
1 Fixed - Roof Mounted
2 1-Axis
3 1-Axis Backtracking
4 2-Axis 
```

Each field is also now saved as a numerical value (float or integer depending on the field, and default values are null.

## Type of change
Please unckeck options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Add Testing
- [X] Refactor

## Checklist:
- [X] My code follows the Turing style guidelines
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas